### PR TITLE
reset values on major/minor bumps

### DIFF
--- a/lib/mix-bump.ex
+++ b/lib/mix-bump.ex
@@ -13,16 +13,16 @@ defmodule MixBump do
   end
 
   def bump_version(file, "major") do
-    file = Regex.replace(@version_regex, file, fn _, major, minor, patch ->
-      "version: \"#{String.to_integer(major) + 1}.#{minor}.#{patch}\""
+    file = Regex.replace(@version_regex, file, fn _, major, _minor, _patch ->
+      "version: \"#{String.to_integer(major) + 1}.#{0}.#{0}\""
     end)
 
     {:ok, file, get_version!(file)}
   end
 
   def bump_version(file, "minor") do
-    file = Regex.replace(@version_regex, file, fn _, major, minor, patch ->
-      "version: \"#{major}.#{String.to_integer(minor) + 1}.#{patch}\""
+    file = Regex.replace(@version_regex, file, fn _, major, minor, _patch ->
+      "version: \"#{major}.#{String.to_integer(minor) + 1}.#{0}\""
     end)
 
     {:ok, file, get_version!(file)}

--- a/test/mix_bump_test.exs
+++ b/test/mix_bump_test.exs
@@ -1,0 +1,28 @@
+defmodule MixBumpTest do
+  use ExUnit.Case
+
+  test "bump_version(major) resets minor and patch to 0" do
+    {:ok, _file, version } =
+      "version: \"0.1.2\"" 
+      |> MixBump.bump_version("major")
+      
+    assert version === "1.0.0"
+    
+  end
+
+  test "bump_version(minor) resets patch to 0" do
+    {:ok, _file, version } =
+      "version: \"0.1.2\"" 
+      |> MixBump.bump_version("minor")
+    
+    assert version === "0.2.0"
+  end
+
+  test "bump_version(patch) does not affect major and minor" do
+    {:ok, _file, version } =
+      "version: \"0.1.2\"" 
+      |> MixBump.bump_version("patch")
+    
+    assert version === "0.1.3"
+  end
+end


### PR DESCRIPTION
This resolves #2 

- [x]  When bumping a **major** version, minor should be set to 0, and patch should be set to 0
- [x]  When bumping a **minor** version, patch should be set to 0
- [x] When bumping a **patch** version, other values should not be affected (current behavior)

Added some real basic tests.