### PR TITLE
Make command adaptable, Add annotated tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This is a simple mix task to version bump a mix project.
   mix bump [major | minor | patch | <newversion>]
 
   options:
-    -m, --message <message>
+    -m, --message  <message>
                      Commit message
     -p, --publish    Publish package to hex
     -t, --tag <name> Specify a tag
+    -a, --annotated  Use annotated tags ( Enabled by default --no-annotated to use simple tags)
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :mix_bump, 
+config :mix_bump,
   command_adapter: MixBump.Command.Shell
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,29 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
+config :mix_bump, 
+  command_adapter: MixBump.Command.Shell
 
-# You can configure your application as:
-#
-#     config :mix_bump, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:mix_bump, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
-config :mix_bump, 
+config :mix_bump,
   command_adapter: MixBump.Command.TestShell

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :mix_bump, 
+  command_adapter: MixBump.Command.TestShell

--- a/lib/mix-bump/command.ex
+++ b/lib/mix-bump/command.ex
@@ -1,5 +1,4 @@
 defmodule MixBump.Command do
-  
   @adapter Application.get_env(:mix_bump, :command_adapter, MixBump.Command.Shell)
 
   defdelegate execute(message), to: @adapter

--- a/lib/mix-bump/command.ex
+++ b/lib/mix-bump/command.ex
@@ -1,7 +1,10 @@
 defmodule MixBump.Command do
-  def execute(command) do
-    if Mix.Shell.IO.cmd(command) == 0, do: :ok, else: :error
-  end
+  
+  @adapter Application.get_env(:mix_bump, :command_adapter, MixBump.Command.Shell)
+
+  defdelegate execute(message), to: @adapter
+
+  defdelegate task(message), to: @adapter
 
   def write(message), do: IO.write(message)
 

--- a/lib/mix-bump/command/adapter.ex
+++ b/lib/mix-bump/command/adapter.ex
@@ -1,0 +1,11 @@
+defmodule MixBump.Command.Adapter do
+  @moduledoc """
+  A small adapter for the execution of shell commands.
+  """
+
+  @callback execute(String.t) :: :ok | :error
+
+  @callback task(String.t) :: any()
+end
+
+

--- a/lib/mix-bump/command/adapter.ex
+++ b/lib/mix-bump/command/adapter.ex
@@ -3,9 +3,7 @@ defmodule MixBump.Command.Adapter do
   A small adapter for the execution of shell commands.
   """
 
-  @callback execute(String.t) :: :ok | :error
+  @callback execute(String.t()) :: :ok | :error
 
-  @callback task(String.t) :: any()
+  @callback task(String.t()) :: any()
 end
-
-

--- a/lib/mix-bump/command/shell.ex
+++ b/lib/mix-bump/command/shell.ex
@@ -13,5 +13,4 @@ defmodule MixBump.Command.Shell do
   def task(task) do
     Mix.Task.run(task)
   end
-
 end

--- a/lib/mix-bump/command/shell.ex
+++ b/lib/mix-bump/command/shell.ex
@@ -1,0 +1,17 @@
+defmodule MixBump.Command.Shell do
+  @moduledoc """
+  A `MixBump.Command` adapter that sends commands to the shell.
+  """
+  @behaviour MixBump.Command.Adapter
+
+  @impl true
+  def execute(command) do
+    if Mix.Shell.IO.cmd(command) == 0, do: :ok, else: :error
+  end
+
+  @impl true
+  def task(task) do
+    Mix.Task.run(task)
+  end
+
+end

--- a/lib/mix-bump/git.ex
+++ b/lib/mix-bump/git.ex
@@ -1,11 +1,31 @@
 defmodule MixBump.Git do
   alias MixBump.Command
 
+  @doc """
+  Commits the modified mix file, with a custom message. You can specify this 
+  message with `--message` or `-m` when running the CLI. Default message is 
+  `Bump version to NEW_VERSION`
+  """
+  @spec commit(String.t) :: :ok | :error
   def commit(message) do
     Command.execute("git commit -o mix.exs -m '#{message}' -q")
   end
 
-  def tag(name) do
-    Command.execute("git tag #{name}")
+  @doc """
+  Tags the release. In the CLI, the flags `--annotated` and `--no-annotated` 
+  determines if tagging will be simple, or annotated. Defaults to annotated.
+  """
+  @type tag_options :: map
+  @type tag_name :: String.t
+
+  @spec tag(tag_name, tag_options) :: :ok | :error
+  def tag(name, options \\ %{})
+
+  def tag(name, %{message: message, annotated: true}) do
+    Command.execute("git tag -a '#{name}' -m '#{message}'")
+  end
+
+  def tag(name, _options) do
+    Command.execute("git tag '#{name}'")
   end
 end

--- a/lib/mix-bump/git.ex
+++ b/lib/mix-bump/git.ex
@@ -6,7 +6,7 @@ defmodule MixBump.Git do
   message with `--message` or `-m` when running the CLI. Default message is 
   `Bump version to NEW_VERSION`
   """
-  @spec commit(String.t) :: :ok | :error
+  @spec commit(String.t()) :: :ok | :error
   def commit(message) do
     Command.execute("git commit -o mix.exs -m '#{message}' -q")
   end
@@ -16,7 +16,7 @@ defmodule MixBump.Git do
   determines if tagging will be simple, or annotated. Defaults to annotated.
   """
   @type tag_options :: map
-  @type tag_name :: String.t
+  @type tag_name :: String.t()
 
   @spec tag(tag_name, tag_options) :: :ok | :error
   def tag(name, options \\ %{})

--- a/lib/mix/tasks/bump.ex
+++ b/lib/mix/tasks/bump.ex
@@ -51,8 +51,7 @@ defmodule Mix.Tasks.Bump do
     annotated = Keyword.get(options, :annotated, true)
 
     with :ok <- Git.commit(message),
-         :ok <- Git.tag(tag_name, %{message: message, annotated: annotated})
-    do
+         :ok <- Git.tag(tag_name, %{message: message, annotated: annotated}) do
       Command.callback(:ok)
     else
       _ -> Command.callback(:error)

--- a/lib/mix/tasks/bump.ex
+++ b/lib/mix/tasks/bump.ex
@@ -10,14 +10,15 @@ defmodule Mix.Tasks.Bump do
                          Commit message
         -p, --publish    Publish package to hex
         -t, --tag <name> Specify a tag
+        -a, --annotated  Use annotated tags (Enabled by default, use --no-annotated to use simple tags)
   """
 
   alias MixBump
   alias MixBump.{Command, Git}
 
   @parse_opts [
-    switches: [message: :string, publish: :boolean, tag: :string],
-    aliases: [m: :message, p: :publish, t: :tag]
+    switches: [message: :string, publish: :boolean, tag: :string, annotated: :boolean],
+    aliases: [m: :message, p: :publish, t: :tag, a: :annotated]
   ]
 
   def run(args) do
@@ -47,16 +48,18 @@ defmodule Mix.Tasks.Bump do
 
     message = Keyword.get(options, :message, "Bump version to #{new_version}")
     tag_name = if name = Keyword.get(options, :tag), do: name, else: "v#{new_version}"
+    annotated = Keyword.get(options, :annotated, true)
 
     with :ok <- Git.commit(message),
-         :ok <- Git.tag(tag_name) do
+         :ok <- Git.tag(tag_name, %{message: message, annotated: annotated})
+    do
       Command.callback(:ok)
     else
       _ -> Command.callback(:error)
     end
 
     if Keyword.get(options, :publish) do
-      Mix.Task.run("hex.publish") && Command.rainbow("Congrats on publishing a new package!")
+      Command.task("hex.publish") && Command.rainbow("Congrats on publishing a new package!")
     else
       Command.rainbow("Bump version to #{new_version}!")
     end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Bump.Mixfile do
       app: :mix_bump,
       version: "0.0.4",
       elixir: "~> 1.5",
+      elixirc_paths: elixirc_paths(Mix.env),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs(),
@@ -44,4 +45,8 @@ defmodule Bump.Mixfile do
       links: %{Github: "https://github.com/oo6/mix-bump"}
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Bump.Mixfile do
       app: :mix_bump,
       version: "0.0.4",
       elixir: "~> 1.5",
-      elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs(),
@@ -48,5 +48,5 @@ defmodule Bump.Mixfile do
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/mix-bump/git_test.exs
+++ b/test/mix-bump/git_test.exs
@@ -5,21 +5,19 @@ defmodule MixBump.GitTest do
 
   test "Git.commit creates a commit with only the mix.exs file, using the provided message" do
     assert capture_io(fn ->
-      Git.commit("IT IS DONE!")
-    end) =~ ~s(git commit -o mix.exs -m 'IT IS DONE!' -q)
+             Git.commit("IT IS DONE!")
+           end) =~ ~s(git commit -o mix.exs -m 'IT IS DONE!' -q)
   end
 
   test "Git.tag will create annotated tags when annotated tagging is enabled" do
     assert capture_io(fn ->
-      Git.tag("v1.0.0", %{message: "first release", annotated: true})
-    end) =~ ~s(git tag -a 'v1.0.0' -m 'first release')
+             Git.tag("v1.0.0", %{message: "first release", annotated: true})
+           end) =~ ~s(git tag -a 'v1.0.0' -m 'first release')
   end
 
   test "Git.tag will create simple tags when annotated tagging is disabled" do
     assert capture_io(fn ->
-      Git.tag("v1.0.0", %{message: "first release", annotated: false})
-    end) =~ ~s(git tag 'v1.0.0')
+             Git.tag("v1.0.0", %{message: "first release", annotated: false})
+           end) =~ ~s(git tag 'v1.0.0')
   end
-
-
 end

--- a/test/mix-bump/git_test.exs
+++ b/test/mix-bump/git_test.exs
@@ -1,0 +1,25 @@
+defmodule MixBump.GitTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+  alias MixBump.Git
+
+  test "Git.commit creates a commit with only the mix.exs file, using the provided message" do
+    assert capture_io(fn ->
+      Git.commit("IT IS DONE!")
+    end) =~ ~s(git commit -o mix.exs -m 'IT IS DONE!' -q)
+  end
+
+  test "Git.tag will create annotated tags when annotated tagging is enabled" do
+    assert capture_io(fn ->
+      Git.tag("v1.0.0", %{message: "first release", annotated: true})
+    end) =~ ~s(git tag -a 'v1.0.0' -m 'first release')
+  end
+
+  test "Git.tag will create simple tags when annotated tagging is disabled" do
+    assert capture_io(fn ->
+      Git.tag("v1.0.0", %{message: "first release", annotated: false})
+    end) =~ ~s(git tag 'v1.0.0')
+  end
+
+
+end

--- a/test/mix/tasks/bump_test.exs
+++ b/test/mix/tasks/bump_test.exs
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.BumpTest do
   import ExUnit.CaptureIO
   alias Mix.Tasks.Bump
 
-  @version Mix.Project.config[:version]
+  @version Mix.Project.config()[:version]
 
   # capturing IO, rather than running the command. 
   # Commands that shell out end in a new line, so we can check the command end
@@ -11,38 +11,37 @@ defmodule Mix.Tasks.BumpTest do
 
   test "bump with annotated tags by default" do
     assert capture_io(fn ->
-      Bump.run([@version])
-    end) =~ ~s(git tag -a 'v#{@version}' -m 'Bump version to #{@version}'\n)
+             Bump.run([@version])
+           end) =~ ~s(git tag -a 'v#{@version}' -m 'Bump version to #{@version}'\n)
   end
 
   test "bump uses simple tags when specified" do
     assert capture_io(fn ->
-      Bump.run([@version, "--no-annotated"])
-    end) =~ ~s(git tag 'v#{@version}'\n)
+             Bump.run([@version, "--no-annotated"])
+           end) =~ ~s(git tag 'v#{@version}'\n)
   end
 
   test "bump uses a custom tag value when specified" do
     assert capture_io(fn ->
-      Bump.run([@version, "--no-annotated", "--tag", "custom"])
-    end) =~ ~s(git tag 'custom'\n)
+             Bump.run([@version, "--no-annotated", "--tag", "custom"])
+           end) =~ ~s(git tag 'custom'\n)
   end
 
   test "bump uses a custom commit message when specified" do
     assert capture_io(fn ->
-      Bump.run([@version, "--message", "custom"])
-    end) =~ ~s(git commit -o mix.exs -m 'custom' -q\n)
+             Bump.run([@version, "--message", "custom"])
+           end) =~ ~s(git commit -o mix.exs -m 'custom' -q\n)
   end
 
   test "bump commits, then tags" do
     assert capture_io(fn ->
-      Bump.run([@version])
-    end) =~ ~s(git commit -o mix.exs -m 'Bump version to #{@version}' -q\ngit tag)
+             Bump.run([@version])
+           end) =~ ~s(git commit -o mix.exs -m 'Bump version to #{@version}' -q\ngit tag)
   end
 
   test "bump publishes when specified" do
     assert capture_io(fn ->
-      Bump.run([@version, "--publish"])
-    end) =~ ~s(hex.publish)
+             Bump.run([@version, "--publish"])
+           end) =~ ~s(hex.publish)
   end
-
 end

--- a/test/mix/tasks/bump_test.exs
+++ b/test/mix/tasks/bump_test.exs
@@ -1,0 +1,48 @@
+defmodule Mix.Tasks.BumpTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+  alias Mix.Tasks.Bump
+
+  @version Mix.Project.config[:version]
+
+  # capturing IO, rather than running the command. 
+  # Commands that shell out end in a new line, so we can check the command end
+  # by including it.
+
+  test "bump with annotated tags by default" do
+    assert capture_io(fn ->
+      Bump.run([@version])
+    end) =~ ~s(git tag -a 'v#{@version}' -m 'Bump version to #{@version}'\n)
+  end
+
+  test "bump uses simple tags when specified" do
+    assert capture_io(fn ->
+      Bump.run([@version, "--no-annotated"])
+    end) =~ ~s(git tag 'v#{@version}'\n)
+  end
+
+  test "bump uses a custom tag value when specified" do
+    assert capture_io(fn ->
+      Bump.run([@version, "--no-annotated", "--tag", "custom"])
+    end) =~ ~s(git tag 'custom'\n)
+  end
+
+  test "bump uses a custom commit message when specified" do
+    assert capture_io(fn ->
+      Bump.run([@version, "--message", "custom"])
+    end) =~ ~s(git commit -o mix.exs -m 'custom' -q\n)
+  end
+
+  test "bump commits, then tags" do
+    assert capture_io(fn ->
+      Bump.run([@version])
+    end) =~ ~s(git commit -o mix.exs -m 'Bump version to #{@version}' -q\ngit tag)
+  end
+
+  test "bump publishes when specified" do
+    assert capture_io(fn ->
+      Bump.run([@version, "--publish"])
+    end) =~ ~s(hex.publish)
+  end
+
+end

--- a/test/support/test_shell.ex
+++ b/test/support/test_shell.ex
@@ -1,5 +1,4 @@
 defmodule MixBump.Command.TestShell do
-
   @moduledoc """
   A `MixBump.Command` adapter that sends commands to stdout, enabling them to 
   be captured in tests

--- a/test/support/test_shell.ex
+++ b/test/support/test_shell.ex
@@ -1,0 +1,20 @@
+defmodule MixBump.Command.TestShell do
+
+  @moduledoc """
+  A `MixBump.Command` adapter that sends commands to stdout, enabling them to 
+  be captured in tests
+  """
+  @behaviour MixBump.Command.Adapter
+
+  @impl true
+  def execute(message) do
+    IO.puts(message)
+    :ok
+  end
+
+  @impl true
+  def task(message) do
+    IO.puts(message)
+    :ok
+  end
+end


### PR DESCRIPTION
Addresses #4 

Annotated tags are enabled by default, though I can default to simple tags if you'd prefer. 

Since Bump is basically just shelling out here, it's kind of hard to test the logic without screwing up your local repo. As a makeshift solution, I made a behaviour for the `MixBump.Command` module, and wrote a quick test adapter that redirects the command to stdout. The test suite then just makes assertions against captured IO.

